### PR TITLE
Add automation release note

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+changelog:
+  exclude:
+    authors:
+      - github-actions
+    labels:
+      - release
+  categories:
+    - title: New Features
+      labels:
+        - 'enhancement'
+    - title: Bug Fix
+      labels:
+        - 'bug'
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/workflows/automation-pr-label.yml
+++ b/.github/workflows/automation-pr-label.yml
@@ -1,0 +1,36 @@
+name: Automatically labeling pull request.
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-labeling-pr:
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # ラベル名を取得する
+      - name: Get label name
+        id: label_name
+        run: |
+          branch_type=$(echo ${{github.head_ref}} | cut -d "/" -f1)
+          if [ $branch_type == 'feature' ]; then
+            label_name=$(echo "enhancement")
+          elif [ $branch_type == 'bugfix' ] || [ $branch_type == 'hotfix' ]; then
+            label_name=$(echo "bug")
+          else
+            label_name=""
+          fi
+          echo "::set-output name=label_name::$label_name"
+
+      # PRにラベルを付与する
+      - name: Auto labeling
+        if: ${{ steps.label_name.outputs.label_name }}
+        run: |
+          number=$(echo $GITHUB_REF | sed -e 's/[^0-9]//g')
+          gh pr edit $number --add-label ${{ steps.label_name.outputs.label_name }}

--- a/.github/workflows/automation-release-note.yml
+++ b/.github/workflows/automation-release-note.yml
@@ -1,0 +1,49 @@
+name: Create release tag and release note.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  create-release-tag:
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TZ: 'Asia/Tokyo'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # 前回のりリースタグを取得する
+      - name: Get previous tag
+        id: pre_tag
+        run: |
+          echo "::set-output name=pre_tag::$(curl -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)"
+
+      # タグを生成する 「{YYYY.MM.DD}-{当日リリース回数}」
+      - name: Generate release tag
+        id: release_tag
+        run: |
+          today=$(date +'%Y.%m.%d')
+          pre_release_date=$(echo ${{ steps.pre_tag.outputs.pre_tag }} | awk -F'-' '{print $1}')
+          pre_release_count=$(echo ${{ steps.pre_tag.outputs.pre_tag }} | awk -F'-' '{print $2}')
+          if [[ ! $pre_release_date = $today ]]; then
+            echo "init count"
+            pre_release_count=0
+          fi
+          echo "::set-output name=release_tag::v$today-$(($pre_release_count + 1))"
+
+      # 前回リリースからの差分をもとに、リリースノートの本文を生成する
+      - name: Generate release note
+        id: release_note
+        run: |
+          echo "::set-output name=release_note::$(curl -X POST -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/releases/generate-notes -d '{"tag_name":"${{ steps.release_tag.outputs.release_tag }}", "previous_tag_name":"${{ steps.pre_tag.outputs.pre_tag }}"}' | jq .body | sed 's/"//g')"
+
+      # タグを切り、リリースノートを作成する
+      - name: Create Release
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -d "{ \"tag_name\": \"${{ steps.release_tag.outputs.release_tag }}\", \"name\": \"${{ steps.release_tag.outputs.release_tag }}\", \"body\": \"${{ steps.release_note.outputs.release_note }}\"}" \
+            https://api.github.com/repos/${{ github.repository }}/releases

--- a/.github/workflows/automation-release-pr.yml
+++ b/.github/workflows/automation-release-pr.yml
@@ -1,0 +1,31 @@
+name: Create a pull request for release.
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # リリース用PRが既に存在するかどうかをチェック
+      - name: Check if pr exists
+        id: check_pr
+        run: |
+          pr_title='release'
+          base_branch='main'
+          echo "::set-output name=count::$(gh pr list -S ${pr_title}' in:title' -B $base_branch | wc -l)"
+          echo "::set-output name=pr_title::$pr_title"
+          echo "::set-output name=base_branch::$base_branch"
+
+      # リリース用PRを作成
+      - name: Create release pr
+        if: ${{ steps.check_pr.outputs.count == 0 }}
+        run: |
+          gh pr create -B ${{ steps.check_pr.outputs.base_branch }} -t ${{ steps.check_pr.outputs.pr_title }} -b "" -l "release"


### PR DESCRIPTION
## 概要

- リリースノートが自動で生成されるように改修

## 関連

- https://zenn.dev/kshida/articles/auto-generate-release-note-with-calver
- https://zenn.dev/kshida/articles/auto-generate-release-pr-with-github-actions