### PR TITLE
fix: amplify config

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -5,7 +5,7 @@ applications:
       phases:
         preTest:
           commands:
-            - nvm use 22
+            - nvm use 24
             - node -v
             - corepack enable
             - npm ci
@@ -18,12 +18,13 @@ applications:
             - npm run test
         preBuild:
           commands:
-            - nvm use 22
+            - nvm use 24
             - node -v
             - corepack enable
             - npm ci
         build:
           commands:
+            - rm -rf .next
             - npm run build
       artifacts:
         baseDirectory: .next
@@ -37,7 +38,7 @@ applications:
       phases:
         preTest:
           commands:
-            - nvm use 22
+            - nvm use 24
             - node -v
             - corepack enable
             - npm ci
@@ -50,7 +51,7 @@ applications:
             - npm run test
         preBuild:
           commands:
-            - nvm use 22
+            - nvm use 24
             - node -v
             - corepack enable
             - npm ci


### PR DESCRIPTION
## 概要

- amplifyの設定を修正
  - Sentry + Next.js 16 + AWS Amplify SSR の組み合わせで発生する問題の修正
    - import-in-the-middle はSentryがサーバーサイドの計装に使用するパッケージ
    - Amplifyがビルドアーティファクトをバンドルする際、.next/node_modules内にランダムハッシュ付きディレクトリが作成される
    - キャッシュされた.nextと新規ビルドで競合が発生
    - 解決策: ビルド前に.nextディレクトリを削除
  - Node.jsのバージョンを24にできるかテスト

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Amplify pipelines to Node 24 and removes `.next` before building to prevent stale artifacts.
> 
> - **CI/Amplify (`amplify.yml`)**:
>   - **Node.js version**: Update `nvm use` from `22` to `24` in `preTest` and `preBuild` for `src/app/frontend` and `src/app/frontend/.storybook`.
>   - **Build step (frontend)**: Add `rm -rf .next` before `npm run build` to ensure a clean build directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abbb4fb1d9b1df308e0adb1304d255e0c062b794. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->