### PR TITLE
upgrade node v 24

### DIFF
--- a/src/app/frontend/package.json
+++ b/src/app/frontend/package.json
@@ -83,10 +83,10 @@
     "vitest": "^4.0.16"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "volta": {
-    "node": "22.20.0"
+    "node": "24.5.0"
   },
   "browserslist": [
     "last 1 Chrome versions",

--- a/src/app/frontend/src/proxy.ts
+++ b/src/app/frontend/src/proxy.ts
@@ -21,7 +21,7 @@ const I18nMiddleware = createI18nMiddleware({
   },
 })
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   return I18nMiddleware(request)
 }
 


### PR DESCRIPTION
## 概要

- Node.jsのバージョンをv24にアップ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raises Node.js requirement to v24 and renames the i18n middleware export from `middleware` to `proxy`.
> 
> - **Config**:
>   - Update Node engine to `>=24.0.0` and Volta pin to `24.5.0` in `src/app/frontend/package.json`.
> - **i18n Middleware**:
>   - Rename exported function from `middleware` to `proxy` in `src/app/frontend/src/proxy.ts` (logic unchanged).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd28e53f40153efc1748746238f0f8e261f9e92a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->