### PR TITLE
fix: min-release-age

### DIFF
--- a/src/app/frontend/.npmrc
+++ b/src/app/frontend/.npmrc
@@ -1,1 +1,1 @@
-min-release-age=1d
+min-release-age=1


### PR DESCRIPTION
## 概要

- min-release-ageの記述を修正

## 関連

- https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age