### PR TITLE
perf: 静的アセットに immutable な Cache-Control を付与

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,18 @@
+# Cloudflare Workers Static Assets header rules.
+# https://developers.cloudflare.com/workers/static-assets/headers/
+#
+# Long-lived immutable caching for assets whose URL changes when their content
+# changes, so the browser never needs to revalidate them:
+#
+#   /_next/static/*  : filenames embed a content hash (emitted by `next build`).
+#   /assets/*        : referenced in HTML with a build-time `?ver=` cache buster
+#                      (see NEXT_PUBLIC_CACHE_BUSTER in next.config.js).
+#
+# Non-versioned root files (e.g. /ads.txt, /robots.txt, /sitemap.xml) are
+# intentionally NOT matched here and keep their default caching.
+
+/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## 背景

afterworks.jp のパフォーマンスレビューで、静的アセットが毎回再検証されている課題が判明した。

`/_next/static/*`（ハッシュ付き）も `/assets/*`（`?ver=` 付き）も URL が内容と連動するにもかかわらず、`Cache-Control: public, max-age=0, must-revalidate` が返っており、`cf-cache-status: HIT` でもブラウザは毎回再検証していた。

本 PR では `public/_headers` を追加し、内容と URL が連動するアセットを `immutable` 化する。これがレビューの第一弾（課題1）。画像最適化（課題2）と TTFB（課題3）は本タスク対象外。

## 変更内容

`public/_headers` を新規作成し、以下のルールを追加。

```
/_next/static/*
  Cache-Control: public, max-age=31536000, immutable

/assets/*
  Cache-Control: public, max-age=31536000, immutable
```

## 計測値（参考・Brotli 圧縮後の実転送量）

| 項目 | 値 |
|---|---|
| JS | 約 272KB / 16 チャンク（最大 72KB） |
| 背景画像 `img-page-background.webp` | 1.71MB（全ページ preload・別タスクで最適化予定） |
| 静的アセットの現状ヘッダー | `public, max-age=0, must-revalidate`（毎回再検証） |

ハッシュ付き / `?ver=` 付きアセットはリピート訪問のたびに再検証往復が発生していた。本変更でこれを解消する。

## なぜ安全か

- ブラウザの HTTP キャッシュはクエリ文字列を含む URL 全体をキーにするため、`?ver=` が変われば別 URL 扱いになり新しいファイルを取得する。`immutable` を付けても「古いアセットが残り続ける」事故は起きない。
- `/_next/static/*` はファイル名自体がコンテンツハッシュなので、変わったファイルだけ URL が変わる。
- `ads.txt` などバージョン無しのルートファイルは対象外にしており、デフォルトのキャッシュ挙動を維持する。
- SSR の HTML は Worker（Next ハンドラ）が返すため、`_headers` の影響を受けない。

## 検証手順 / 実績

- [x] `npm run cf-build` 実行 → ビルド成功
- [x] `.open-next/assets/_headers` にコピーされることを確認（767 bytes・内容一致）
- [x] パターンが実アセットにマッチすることを確認
  - `/_next/static/chunks/*.js`（コンテンツハッシュ付き）→ `/_next/static/*`
  - `/assets/img/img-logo.svg`（`?ver=` 付き参照）→ `/assets/*`

デプロイ後の実ヘッダー確認（未実施・要デプロイ後対応）:

```bash
curl -sS -o /dev/null -D - "https://afterworks.jp/assets/img/img-logo.svg?ver=XXXX" | grep -i cache-control
# 期待値: cache-control: public, max-age=31536000, immutable

curl -sS -o /dev/null -D - "https://afterworks.jp/_next/static/chunks/<any>.js" | grep -i cache-control
# 期待値: cache-control: public, max-age=31536000, immutable
```

## 影響範囲

- 静的アセット（`/_next/static/*`・`/assets/*`）のキャッシュヘッダーのみ。
- アプリのロジックには一切影響しない。
- 万一 `.open-next/assets/_headers` が読まれずヘッダーが変わらない場合は、`workers/app.ts` 側でアセットパスのレスポンスに `Cache-Control` を付与する実装に切り替える（要相談）。

## ロールバック

`public/_headers` を削除して再デプロイすれば元の挙動（`max-age=0, must-revalidate`）に戻る。

## フォローアップ（本 PR 対象外）

- 背景画像 `img-page-background.webp`（3840×2160・RGBA・1.71MB）の最適化（アルファ除去＋リサイズ＋AVIF 化）
- キャッシュバスターの内容ハッシュ化（現状はビルド時刻の一括バスター）
- TTFB 改善（`force-dynamic` の見直し / ISR 化）

https://claude.ai/code/session_01KmNtcxLW4h9pZjXFtaS9cB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmNtcxLW4h9pZjXFtaS9cB)_